### PR TITLE
PIPAL::Direction::evalStep: Use zeros to create vector instead of matrix

### DIFF
--- a/PIPAL/src/Direction.m
+++ b/PIPAL/src/Direction.m
@@ -185,9 +185,9 @@ classdef Direction < handle
         end
         
         % Initialize updating data
-        ltred0_rho_mu = zeros(p.mu_trials);
-        qtred_rho_mu  = zeros(p.mu_trials);
-        m_rho_mu      = zeros(p.mu_trials);
+        ltred0_rho_mu = zeros(p.mu_trials,1);
+        qtred_rho_mu  = zeros(p.mu_trials,1);
+        m_rho_mu      = zeros(p.mu_trials,1);
         
         % Initialize check
         check = 0;


### PR DESCRIPTION
Hi, I think I maybe have found a small issue in the current version of `Direction.m`.
I discovered this while debugging the logic around `m_rho_mu`.

I found that on line 236, we take
```
          m_min = min(m_rho_mu);
```
Since `m_rho_mu` currently is a matrix, and min of a matrix does a column-wise minimum [1], `m_min` ends up as a vector.
Later, on line 239, we then do an if statement:
```
          if m_min < inf
```
which always will turn out true, which I think is not the intended behavior?

I am interested in hearing your thoughts about this and if this is a real issue, or if I have misunderstood something.

[1] https://www.mathworks.com/help/matlab/ref/min.html