### PR TITLE
PIPAL: Add support for defining problems as function handles instead of hard-coded amplfunc calls

### DIFF
--- a/PIPAL/src/Input.m
+++ b/PIPAL/src/Input.m
@@ -43,46 +43,55 @@ classdef Input < handle
     nA % size of primal-dual matrix
     x0 % initial point
     vi % counter for invalid bounds
-    
+    f_orig % original objective
+    c_orig % original constraints
+    g_orig % original gradient of objective
+    J_orig % original jacobian of constraints
+    H_orig % original hessian of the lagrangian
+
   end
   
   % Class methods
   methods
     
     % Constructor
-    function i = Input(p,name,nl)
+    function i = Input(p, name, f_orig, c_orig, g_orig, J_orig, H_orig, x0, bl, bu, l, cl, cu)
       
       % Set problem identity
       i.id = strtrim(name);
       
-      % Initialize AMPL data
-      [a.x,a.bl,a.bu,a.l,a.cl,a.cu] = amplfunc(nl);
+      % store function pointers to original problem functions
+      i.f_orig = f_orig;
+      i.c_orig = c_orig;
+      i.g_orig = g_orig;
+      i.J_orig = J_orig;
+      i.H_orig = H_orig;
       
       % Set number of original formulation variables
-      i.n0 = length(a.x);
+      i.n0 = length(x0);
       
       % Find index sets
-      i.I1 = find(a.bl <= -p.rhs_bnd & a.bu >= p.rhs_bnd);
-      i.I2 = find(a.bl ==  a.bu);
-      i.I3 = find(a.bl >  -p.rhs_bnd & a.bu >= p.rhs_bnd);
-      i.I4 = find(a.bl <= -p.rhs_bnd & a.bu <  p.rhs_bnd);
-      i.I5 = find(a.bl >  -p.rhs_bnd & a.bu <  p.rhs_bnd & a.bl ~= a.bu);
-      i.I6 = find(a.cl ==  a.cu);
-      i.I7 = find(a.cl >  -p.rhs_bnd & a.cu >= p.rhs_bnd);
-      i.I8 = find(a.cl <= -p.rhs_bnd & a.cu <  p.rhs_bnd);
-      i.I9 = find(a.cl >  -p.rhs_bnd & a.cu <  p.rhs_bnd & a.cl ~= a.cu);
+      i.I1 = find(bl <= -p.rhs_bnd & bu >= p.rhs_bnd);
+      i.I2 = find(bl ==  bu);
+      i.I3 = find(bl >  -p.rhs_bnd & bu >= p.rhs_bnd);
+      i.I4 = find(bl <= -p.rhs_bnd & bu <  p.rhs_bnd);
+      i.I5 = find(bl >  -p.rhs_bnd & bu <  p.rhs_bnd & bl ~= bu);
+      i.I6 = find(cl ==  cu);
+      i.I7 = find(cl >  -p.rhs_bnd & cu >= p.rhs_bnd);
+      i.I8 = find(cl <= -p.rhs_bnd & cu <  p.rhs_bnd);
+      i.I9 = find(cl >  -p.rhs_bnd & cu <  p.rhs_bnd & cl ~= cu);
       
       % Set right-hand side values
-      i.b2 = a.bl(i.I2);
-      i.l3 = a.bl(i.I3);
-      i.u4 = a.bu(i.I4);
-      i.l5 = a.bl(i.I5);
-      i.u5 = a.bu(i.I5);
-      i.b6 = a.cl(i.I6);
-      i.l7 = a.cl(i.I7);
-      i.u8 = a.cu(i.I8);
-      i.l9 = a.cl(i.I9);
-      i.u9 = a.cu(i.I9);
+      i.b2 = bl(i.I2);
+      i.l3 = bl(i.I3);
+      i.u4 = bu(i.I4);
+      i.l5 = bl(i.I5);
+      i.u5 = bu(i.I5);
+      i.b6 = cl(i.I6);
+      i.l7 = cl(i.I7);
+      i.u8 = cu(i.I8);
+      i.l9 = cl(i.I9);
+      i.u9 = cu(i.I9);
       
       % Set sizes of index sets
       i.n1 = length(i.I1);
@@ -123,7 +132,7 @@ classdef Input < handle
       i.nA = i.nV + 3*i.nE + 3*i.nI;
       
       % Set initial point
-      i.x0 = [a.x(i.I1); a.x(i.I3); a.x(i.I4); a.x(i.I5);];
+      i.x0 = [x0(i.I1); x0(i.I3); x0(i.I4); x0(i.I5);];
       
     end
     

--- a/PIPAL/src/Iterate.m
+++ b/PIPAL/src/Iterate.m
@@ -144,7 +144,8 @@ classdef Iterate < handle
       try
         
         % Evaluate AMPL functions
-        [z.f,c_orig] = amplfunc(x_orig,0);
+        z.f = i.f_orig(x_orig);
+        c_orig = i.c_orig(x_orig);
         
       catch
         
@@ -197,7 +198,8 @@ classdef Iterate < handle
       try
         
         % Evaluate AMPL gradients
-        [g_orig,J_orig] = amplfunc(x_orig,1);
+        g_orig = i.g_orig(x_orig);
+        J_orig = i.J_orig(x_orig);
         
       catch
         
@@ -239,6 +241,7 @@ classdef Iterate < handle
       
       % Evaluate lambda in original space
       l_orig = z.evalLambdaOriginal(i);
+      x_orig = z.evalXOriginal(i);
       
       % Initialize/Reset evaluation flag
       z.err = 0;
@@ -250,8 +253,8 @@ classdef Iterate < handle
       try
         
         % Evaluate H_orig
-        if (i.nE+i.n7+i.n8+i.n9 == 0), H_orig = amplfunc([]);
-        else                           H_orig = amplfunc(l_orig); end;
+        if (i.nE+i.n7+i.n8+i.n9 == 0), H_orig = i.H_orig(x_orig, []);
+        else                           H_orig = i.H_orig(x_orig, l_orig); end;
         
       catch
         

--- a/PIPAL/src/Pipal.m
+++ b/PIPAL/src/Pipal.m
@@ -21,11 +21,11 @@ classdef Pipal
   methods
     
     % Constructor
-    function P = Pipal(name,nl,outfile,algorithm)
+    function P = Pipal(name, f_orig, c_orig, g_orig, J_orig, H_orig, x0, bl, bu, l, cl, cu, outfile, algorithm)
       
       % Construct classes
       P.p = Parameter(algorithm);
-      P.i = Input(P.p,name,nl)  ;
+      P.i = Input(P.p, name, f_orig, c_orig, g_orig, J_orig, H_orig, x0, bl, bu, l, cl, cu);
       P.o = Output(P.i,outfile) ;
       P.c = Counter             ;
       P.z = Iterate(P.p,P.i,P.c);


### PR DESCRIPTION
This change is only a software architecture change and should not affect the result of the PIPAL algorithm at all.

The motivation for this architecture change is twofold:

1) As written today, the PIPAL algorithm can only be used with `amplfunc`-compatible optimization problems. PIPAL as an algorithm is general, and can work with any NLP problem. This change exposes this generality so that any Matlab function can be used to define the optimization problem.
2) There is implicit state when evaluating the Hessian of the Lagrangian. This function call does not take the primal variables as input, this information must come from a stateful side-channel, the function evaluating the Hessian must "remember" the values of the primal variables. This change also adds the primal variables as an argument when evaluating the Hessian of the Lagrangian, so that we can remove the need for this stateful API.

It is still _easy_ to use the PIPAL algorithm with `amplfunc` after this change. Below is a sample runner script that wraps the `amplfunc` API in such a way that it can be feed to the new PIPAL API.

I do not have strong feelings about the details of this change, I simply want to make it possible to use PIPAL on more optimization problems than those defined as AMPL `.nl` files. Things that could make sense to change are for example:
1) Maybe put `@f_orig, @c_orig, @g_orig, @J_orig, @H_orig` into a struct, so that they are passed as a single argument to the `Pipal()` constructor? A struct could also be used to pass `x0, bl, bu, l, cl, cu`.
2) Maybe bundle together `@g_orig` and `@J_orig` in the same way as `amplfunc`. The way the API is written right now, we will end up evaluating `g_orig` and `J_orig` twice, because `amplfunc` is not able to compute them independently. This could also quite easily be making the wrapper below smarter. So that it `g_orig` stores the computed jacobian in a stateful variable, and `J_orig` simply returns this variable.
3) Probably many other details that can be discussed and changed :)

```matlab
function [] = run_single_ampl_problem(name)
    nl = 'path/to/nl/file.nl');
    [x0,bl,bu,l,cl,cu] = amplfunc(nl);

    basedir = output_basedir();
    outfile = 'my/output/log/path/log.txt';
    algorithm = 1;
    optimizer = Pipal(name, @f_orig, @c_orig, @g_orig, @J_orig, @H_orig, x0, bl, bu, l, cl, cu, outfile, algorithm);

    optimizer.optimize;
    s = optimizer.getSolution;
    % s.x ~ final primal point
    % s.l ~ final dual point
end

function obj_orig = f_orig(x_orig)
    [obj_orig,~] = amplfunc(x_orig,0);
end

function c_orig = c_orig(x_orig)
    [~,c_orig] = amplfunc(x_orig,0);
end

function grad_orig = g_orig(x_orig)
    [grad_orig,~] = amplfunc(x_orig,1);
end

function jac_orig = J_orig(x_orig)
    [~,jac_orig] = amplfunc(x_orig,1);
end

function hessian = H_orig(x_orig, l_orig)
    hessian = amplfunc(l_orig);
end
```